### PR TITLE
Fix broken images on photo-opp blog page

### DIFF
--- a/blog/photo-opp.html
+++ b/blog/photo-opp.html
@@ -40,12 +40,12 @@
         <p>
       </div>
       <div id="thing">
-        <img src="./images/bronkula-room.jpeg" alt="Justin's Home Office" ><br>
+        <img src="/images/bronkula-room.jpeg" alt="Justin's Home Office" ><br>
         This room has become my life. It's been a fascinating process to condense as much into the most efficient space as possible. <a href="https://twitter.com/bronkula">@bronkula</a> <br>
         San Francisco, CA - December 20, 2020
       </div>
       <div id="thing">
-        <img src="./images/home-office.jpg" alt="Justin's Home Office" ><br>
+        <img src="/images/home-office.jpg" alt="Justin's Home Office" ><br>
         Justin's home office, about to post this webpage <br>
         Oakland, CA - December 20, 2020
       </div>


### PR DESCRIPTION
Image paths were relative (./images/) which doesn't resolve from /blog/. Changed to absolute (/images/).