### PR TITLE
Redesign blog with Google search header

### DIFF
--- a/blog/OSSAT17.html
+++ b/blog/OSSAT17.html
@@ -4,29 +4,42 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-    <title>Blog - Open Source Share and Tell</title>
-    <!-- Google tag (gtag.js) -->
+    <link rel="stylesheet" type="text/css" href="/css/search-header.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMVE9GEEQ3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-LMVE9GEEQ3');
     </script>
+    <title>Blog - Open Source Share and Tell</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: arial, sans-serif; color: #202124; background: #fff; }
+    </style>
   </head>
   <body>
-    <header>
-      <div id="about">
-        <a href="/about.html">About</a>
+
+    <div class="search-header">
+      <div class="search-header-inner">
+        <a href="/" class="search-logo">
+          <span class="one">J</span><span class="two">u</span><span class="three">s</span><span class="four">t</span><span class="five">i</span><span class="six">n</span>
+        </a>
+        <div class="search-bar">
+          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+          <input type="text" value="open source show and tell 2017" readonly>
+        </div>
+        <div class="search-tabs">
+          <a href="/about.html">All</a>
+          <a href="https://instagram.com/elof">Images</a>
+          <a href="/blog/" class="active">Blog</a>
+          <a href="https://github.com/elof">Code</a>
+        </div>
       </div>
-      <ul id="header-info">
-        <li id="email"><a href="mailto:justin@rad.as?subject=hi">Email</a></li>
-        <li id="email"><a href="https://instagram.com/elof">Images</a></li>
-        <li><a href="/"><img src="/images/profile-photo.jpg" alt="profile"></li></a>
-      </ul>
-    </header>
-    <div class="post">
+    </div>
+
+    <div class="post-reading">
+
       <h1>What’s up in OSS in 2017</h1>
       <span class="post-meta"><time datetime="2014-03-22">30 May 2017</time></span>
       <p>We are very excited here at <a href="https://keen.io">Keen IO</a> to announce the fourth annual Open Source Show and Tell! The event is Friday, June 9th from 1pm to 5pm in downtown San Francisco. Grab a ticket <a href="http://opensourceshowandtell.com" data-href="http://opensourceshowandtell.com" target="_blank">here</a>.</p>
@@ -45,12 +58,13 @@
       <p>Grab a <a href="http://opensourceshowandtell.com" data-href="http://opensourceshowandtell.com" class="markup--anchor markup--p-anchor" rel="nofollow noopener" target="_blank">ticket</a> and come learn what’s going on in OSS in 2017.</p>
       <p>Feel free to <a href="http://twitter.com/elof" data-href="http://twitter.com/elof" target="_blank">reach out to me with questions</a>. :D</p>
     </div>
-    <footer>
-      <ul>
-        <li id="email"><a href="https://twitter.com/elof">Twitter</a></li>
-        <li id="email"><a href="https://github.com/elof">Github</a></li>
-        <li id="email"><a href="https://linkedin.com/in/elofjohnson">LinkedIn</a></li>
-      </ul>
-    </footer>
+
+    <div class="search-footer">
+      <a href="/">Home</a>
+      <a href="/blog/">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="mailto:justin@rad.as?subject=hi">Contact</a>
+    </div>
+
   </body>
 </html>

--- a/blog/brands.html
+++ b/blog/brands.html
@@ -4,29 +4,42 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-    <title>Blog - Brands Are Like Wine</title>
-    <!-- Google tag (gtag.js) -->
+    <link rel="stylesheet" type="text/css" href="/css/search-header.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMVE9GEEQ3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-LMVE9GEEQ3');
     </script>
+    <title>Blog - Brands Are Like Wine</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: arial, sans-serif; color: #202124; background: #fff; }
+    </style>
   </head>
   <body>
-    <header>
-      <div id="about">
-        <a href="/about.html">About</a>
+
+    <div class="search-header">
+      <div class="search-header-inner">
+        <a href="/" class="search-logo">
+          <span class="one">J</span><span class="two">u</span><span class="three">s</span><span class="four">t</span><span class="five">i</span><span class="six">n</span>
+        </a>
+        <div class="search-bar">
+          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+          <input type="text" value="brands are like wine" readonly>
+        </div>
+        <div class="search-tabs">
+          <a href="/about.html">All</a>
+          <a href="https://instagram.com/elof">Images</a>
+          <a href="/blog/" class="active">Blog</a>
+          <a href="https://github.com/elof">Code</a>
+        </div>
       </div>
-      <ul id="header-info">
-        <li id="email"><a href="mailto:justin@rad.as?subject=hi">Email</a></li>
-        <li id="email"><a href="https://instagram.com/elof">Images</a></li>
-        <li><a href="/"><img src="/images/profile-photo.jpg" alt="profile"></li></a>
-      </ul>
-    </header>
-    <div class="post">
+    </div>
+
+    <div class="post-reading">
+
       <h1 class="post-title">Brands Are Like Wine: I Consume Them Both Irresponsibly</h1>
       <span class="post-meta"><time datetime="2014-05-22">22 May 2014</time> </span>
       <section class="post-content">
@@ -69,12 +82,13 @@
         <p><img src="https://web.archive.org/web/20150221161405im_/https://31.media.tumblr.com/0590a1d29d29ee74c3a35b85048dca6a/tumblr_inline_n5zn90Wcp71socugh.jpg"></p>
       </section>
     </div>
-    <footer>
-      <ul>
-        <li id="email"><a href="https://twitter.com/elof">Twitter</a></li>
-        <li id="email"><a href="https://github.com/elof">Github</a></li>
-        <li id="email"><a href="https://linkedin.com/in/elofjohnson">LinkedIn</a></li>
-      </ul>
-    </footer>
+
+    <div class="search-footer">
+      <a href="/">Home</a>
+      <a href="/blog/">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="mailto:justin@rad.as?subject=hi">Contact</a>
+    </div>
+
   </body>
 </html>

--- a/blog/developer-evangelism.html
+++ b/blog/developer-evangelism.html
@@ -4,29 +4,42 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-    <title>Blog - Developer Evangelism</title>
-    <!-- Google tag (gtag.js) -->
+    <link rel="stylesheet" type="text/css" href="/css/search-header.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMVE9GEEQ3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-LMVE9GEEQ3');
     </script>
+    <title>Blog - Developer Evangelism</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: arial, sans-serif; color: #202124; background: #fff; }
+    </style>
   </head>
   <body>
-    <header>
-      <div id="about">
-        <a href="/about.html">About</a>
+
+    <div class="search-header">
+      <div class="search-header-inner">
+        <a href="/" class="search-logo">
+          <span class="one">J</span><span class="two">u</span><span class="three">s</span><span class="four">t</span><span class="five">i</span><span class="six">n</span>
+        </a>
+        <div class="search-bar">
+          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+          <input type="text" value="developer evangelism Keen IO" readonly>
+        </div>
+        <div class="search-tabs">
+          <a href="/about.html">All</a>
+          <a href="https://instagram.com/elof">Images</a>
+          <a href="/blog/" class="active">Blog</a>
+          <a href="https://github.com/elof">Code</a>
+        </div>
       </div>
-      <ul id="header-info">
-        <li id="email"><a href="mailto:justin@rad.as?subject=hi">Email</a></li>
-        <li id="email"><a href="https://instagram.com/elof">Images</a></li>
-        <li><a href="/"><img src="/images/profile-photo.jpg" alt="profile"></li></a>
-      </ul>
-    </header>
-    <div class="post">
+    </div>
+
+    <div class="post-reading">
+
       <h1 class="code-line" data-line-start=0 data-line-end=1 ><a id="Developer_Evangelism_What_Does_it_Mean_0"></a>Developer Evangelism, What Does it Mean?</h1>
       <span class="post-meta"><time datetime="2014-04-09">12 Dec 2013</time> </span>
       <p class="has-line-data" data-line-start="1" data-line-end="2">Over the past three years, I’ve put a lot of thought into how to approach and engage developer communities around the world. I’ve experimented with running side projects, hosting hackathons and startup competitions, planning and attending meet-ups, contributing to open source projects, giving talks, sitting on panels, going to conventions, and handing out tons of high fives. And all of my various experiences have taught me one super important lesson: Be genuine, and be helpful. As Keen IO’s first Developer Evangelist, I’m tasked with engaging and growing our developer community while sticking to those two core values.</p>
@@ -51,12 +64,13 @@
       One other thing that I really want to get to but haven’t gotten started on yet is helping with the document management for our API’s and SDKs. Oftentimes the real test of a company whose product is code is having easy-to-use and extremely well-documented API’s. Fortunately, our documentation is already pretty good, but eventually I want my team to support the rest of the organization in updating and containing to flesh out the Keen IO docs, possibly to the point where we own that part of the company entirely.</p>
       <p class="has-line-data" data-line-start="30" data-line-end="31">Like I said, this is only the beginning. I’m always open to new ideas or suggestions - feel free to send along your ideas, or hit me up for pointers if you’re building your own Developer Evangelism program.</p>
     </div>
-    <footer>
-      <ul>
-        <li id="email"><a href="https://twitter.com/elof">Twitter</a></li>
-        <li id="email"><a href="https://github.com/elof">Github</a></li>
-        <li id="email"><a href="https://linkedin.com/in/elofjohnson">LinkedIn</a></li>
-      </ul>
-    </footer>
+
+    <div class="search-footer">
+      <a href="/">Home</a>
+      <a href="/blog/">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="mailto:justin@rad.as?subject=hi">Contact</a>
+    </div>
+
   </body>
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,51 +4,170 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-    <title>Rad Blog</title>
-    <!-- Google tag (gtag.js) -->
+    <link rel="stylesheet" type="text/css" href="/css/search-header.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMVE9GEEQ3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-LMVE9GEEQ3');
     </script>
+    <title>Justin Johnson — Blog</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: arial, sans-serif; color: #202124; background: #fff; }
+    </style>
   </head>
   <body>
-    <header>
-      <div id="about">
-        <a href="/about.html">About</a>
+
+    <div class="search-header">
+      <div class="search-header-inner">
+        <a href="/" class="search-logo">
+          <span class="one">J</span><span class="two">u</span><span class="three">s</span><span class="four">t</span><span class="five">i</span><span class="six">n</span>
+        </a>
+        <div class="search-bar">
+          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+          <input type="text" value="Justin Johnson blog" readonly>
+        </div>
+        <div class="search-tabs">
+          <a href="/about.html">All</a>
+          <a href="https://instagram.com/elof">Images</a>
+          <a href="/blog/" class="active">Blog</a>
+          <a href="https://github.com/elof">Code</a>
+        </div>
       </div>
-      <ul id="header-info">
-        <li id="email"><a href="mailto:justin@rad.as?subject=hi">Email</a></li>
-        <li id="email"><a href="https://instagram.com/elof">Images</a></li>
-        <li><a href="/"><img src="/images/profile-photo.jpg" alt="profile"></li></a>
-      </ul>
-    </header>
-    <div class="post">
-      <h1>Posts</h1>
-      <ul class="listPosts">
-        <li><a href="/blog/photo-opp.html">Photo Opp</a></li>
-        <li><a href="/blog/screensaver.html">Screensaver</a></li>
-        <li><a href="/blog/strangerloops.html">I Gave an AI a Name and It Started a Blog</a></li>
-        <li><a href="/blog/strangerloops-technical.html">StrangerLoops: The Technical Bits</a></li>
-        <li><a href="/blog/lyft.html">Notes from my 2012 Interview with Lyft Co-Founder, Logan Green</li>
-        <li><a href="/blog/listen.html">Listen to This</a></li>
-        <li><a href="/blog/OSSAT17.html">What's Up in Open Source in 2017?</a></li>
-        <li><a href="/blog/brands.html">Brands Are Like Wine</a></li>
-        <li><a href="/blog/san-francisco.html">What Are You the Way You Are, San Francisco</a></li>
-        <li><a href="/blog/inspiration.html">Inspiration</a></li>
-        <li><a href="/blog/what-happened-to-latelabs.html">What happened to LateLabs?</a></li>
-        <li><a href="/blog/developer-evangelism.html">Developer Evangelism, What Does it Mean?</a></li>
-      </ul>
     </div>
-    <footer>
-      <ul>
-        <li id="email"><a href="https://twitter.com/elof">Twitter</a></li>
-        <li id="email"><a href="https://github.com/elof">Github</a></li>
-        <li id="email"><a href="https://linkedin.com/in/elofjohnson">LinkedIn</a></li>
-      </ul>
-    </footer>
+
+    <div class="results-main">
+      <div class="result-stats">About 12 results (0.28 seconds)</div>
+
+      <div class="result">
+        <div class="result-url">
+          <span class="favicon">R</span>
+          <span class="site-name">rad.as</span>
+          <span class="breadcrumb"> › blog › strangerloops</span>
+        </div>
+        <div class="result-title"><a href="/blog/strangerloops.html">I Gave an AI a Name and It Started a Blog</a></div>
+        <div class="result-snippet"><span class="result-date">Feb 10, 2026 — </span>A friend invited me to check out StrangerLoops — a guidebook for setting up <b>AI agents</b> that actually persist. Not chatbots. Agents with memory, identity, and a daily rhythm.</div>
+      </div>
+
+      <div class="result">
+        <div class="result-url">
+          <span class="favicon">R</span>
+          <span class="site-name">rad.as</span>
+          <span class="breadcrumb"> › blog › strangerloops-technical</span>
+        </div>
+        <div class="result-title"><a href="/blog/strangerloops-technical.html">StrangerLoops: The Technical Bits</a></div>
+        <div class="result-snippet"><span class="result-date">Feb 10, 2026 — </span>How you actually turn a language model into a persistent agent with identity, memory, and a daily rhythm. It's simpler than you'd think.</div>
+      </div>
+
+      <div class="result">
+        <div class="result-url">
+          <span class="favicon">R</span>
+          <span class="site-name">rad.as</span>
+          <span class="breadcrumb"> › blog › photo-opp</span>
+        </div>
+        <div class="result-title"><a href="/blog/photo-opp.html">Photo Opp</a></div>
+        <div class="result-snippet"><span class="result-date">Dec 20, 2020 — </span>All over the world people are living their lives. Share a photo that captures something happening in your daily life.</div>
+      </div>
+
+      <div class="result">
+        <div class="result-url">
+          <span class="favicon">R</span>
+          <span class="site-name">rad.as</span>
+          <span class="breadcrumb"> › blog › lyft</span>
+        </div>
+        <div class="result-title"><a href="/blog/lyft.html">Notes from my 2012 Interview with Lyft Co-Founder, Logan Green</a></div>
+        <div class="result-snippet"><span class="result-date">Mar 29, 2019 — </span>Back before Lyft was a household name I was working on an article for VentureBeat about the <b>sharing economy</b>. I had the pleasure of interviewing Lyft's co-founder.</div>
+      </div>
+
+      <div class="result">
+        <div class="result-url">
+          <span class="favicon">R</span>
+          <span class="site-name">rad.as</span>
+          <span class="breadcrumb"> › blog › listen</span>
+        </div>
+        <div class="result-title"><a href="/blog/listen.html">Listen to This</a></div>
+        <div class="result-snippet"><span class="result-date">Oct 28, 2018 — </span>How I became a more productive and happy reader. I have the triple whammy of <b>dyslexia</b>, ADHD, and poor vision. Text to speech technology changed everything.</div>
+      </div>
+
+      <div class="result">
+        <div class="result-url">
+          <span class="favicon">R</span>
+          <span class="site-name">rad.as</span>
+          <span class="breadcrumb"> › blog › OSSAT17</span>
+        </div>
+        <div class="result-title"><a href="/blog/OSSAT17.html">What's Up in Open Source in 2017?</a></div>
+        <div class="result-snippet"><span class="result-date">May 30, 2017 — </span>Announcing the fourth annual <b>Open Source Show and Tell</b>, partnering with Google Cloud, GitHub, and Microsoft. Downtown San Francisco.</div>
+      </div>
+
+      <div class="result">
+        <div class="result-url">
+          <span class="favicon">R</span>
+          <span class="site-name">rad.as</span>
+          <span class="breadcrumb"> › blog › what-happened-to-latelabs</span>
+        </div>
+        <div class="result-title"><a href="/blog/what-happened-to-latelabs.html">What Happened to Late Labs?</a></div>
+        <div class="result-snippet"><span class="result-date">Aug 7, 2015 — </span>It's been a little over two years since I stopped working on Late Labs and eventually, quietly, shut it down. The business model didn't end up working.</div>
+      </div>
+
+      <div class="result">
+        <div class="result-url">
+          <span class="favicon">R</span>
+          <span class="site-name">rad.as</span>
+          <span class="breadcrumb"> › blog › brands</span>
+        </div>
+        <div class="result-title"><a href="/blog/brands.html">Brands Are Like Wine: I Consume Them Both Irresponsibly</a></div>
+        <div class="result-snippet"><span class="result-date">May 22, 2014 — </span>There is actually a lot of overlap between the experience of a great wine and the experience of a great <b>brand</b>. Look, Smell, and Taste.</div>
+      </div>
+
+      <div class="result">
+        <div class="result-url">
+          <span class="favicon">R</span>
+          <span class="site-name">rad.as</span>
+          <span class="breadcrumb"> › blog › san-francisco</span>
+        </div>
+        <div class="result-title"><a href="/blog/san-francisco.html">Why Are You the Way You Are, San Francisco</a></div>
+        <div class="result-snippet"><span class="result-date">Apr 9, 2014 — </span>One of the most important aspects of SF is that it's always reinventing itself. It's the wild west and the gold rush. It's the land of opportunity.</div>
+      </div>
+
+      <div class="result">
+        <div class="result-url">
+          <span class="favicon">R</span>
+          <span class="site-name">rad.as</span>
+          <span class="breadcrumb"> › blog › inspiration</span>
+        </div>
+        <div class="result-title"><a href="/blog/inspiration.html">Where Do You Find Inspiration?</a></div>
+        <div class="result-snippet"><span class="result-date">Mar 22, 2014 — </span>The most common way I'm inspired is over drinks at a bar one-on-one talking about nothing in particular. I'm a sucker for good drinks and meandering conversation.</div>
+      </div>
+
+      <div class="result">
+        <div class="result-url">
+          <span class="favicon">R</span>
+          <span class="site-name">rad.as</span>
+          <span class="breadcrumb"> › blog › developer-evangelism</span>
+        </div>
+        <div class="result-title"><a href="/blog/developer-evangelism.html">Developer Evangelism, What Does It Mean?</a></div>
+        <div class="result-snippet"><span class="result-date">Dec 12, 2013 — </span>As <b>Keen IO's</b> first Developer Evangelist, I'm tasked with engaging and growing our developer community. Be genuine, and be helpful.</div>
+      </div>
+
+      <div class="result">
+        <div class="result-url">
+          <span class="favicon">R</span>
+          <span class="site-name">rad.as</span>
+          <span class="breadcrumb"> › blog › screensaver</span>
+        </div>
+        <div class="result-title"><a href="/blog/screensaver.html">Screensaver</a></div>
+        <div class="result-snippet">An interactive screensaver. Just two words bouncing around. Sometimes that's enough.</div>
+      </div>
+    </div>
+
+    <div class="search-footer">
+      <a href="/">Home</a>
+      <a href="/about.html">About</a>
+      <a href="https://aoai.dev">Agent</a>
+      <a href="mailto:justin@rad.as?subject=hi">Contact</a>
+    </div>
+
   </body>
 </html>

--- a/blog/inspiration.html
+++ b/blog/inspiration.html
@@ -4,29 +4,42 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-    <title>Blog - Inspiration</title>
-    <!-- Google tag (gtag.js) -->
+    <link rel="stylesheet" type="text/css" href="/css/search-header.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMVE9GEEQ3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-LMVE9GEEQ3');
     </script>
+    <title>Blog - Inspiration</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: arial, sans-serif; color: #202124; background: #fff; }
+    </style>
   </head>
   <body>
-    <header>
-      <div id="about">
-        <a href="/about.html">About</a>
+
+    <div class="search-header">
+      <div class="search-header-inner">
+        <a href="/" class="search-logo">
+          <span class="one">J</span><span class="two">u</span><span class="three">s</span><span class="four">t</span><span class="five">i</span><span class="six">n</span>
+        </a>
+        <div class="search-bar">
+          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+          <input type="text" value="where do you find inspiration" readonly>
+        </div>
+        <div class="search-tabs">
+          <a href="/about.html">All</a>
+          <a href="https://instagram.com/elof">Images</a>
+          <a href="/blog/" class="active">Blog</a>
+          <a href="https://github.com/elof">Code</a>
+        </div>
       </div>
-      <ul id="header-info">
-        <li id="email"><a href="mailto:justin@rad.as?subject=hi">Email</a></li>
-        <li id="email"><a href="https://instagram.com/elof">Images</a></li>
-        <li><a href="/"><img src="/images/profile-photo.jpg" alt="profile"></li></a>
-      </ul>
-    </header>
-    <div class="post">
+    </div>
+
+    <div class="post-reading">
+
       <h1 class="post-title">Where do you find inspiration?</h1>
       <span class="post-meta"><time datetime="2014-03-22">22 Mar 2014</time></span>
       <section class="post-content">
@@ -39,12 +52,13 @@
         <p><img src="https://web.archive.org/web/20150221074533im_/http://1.bp.blogspot.com/_EGQ23oGWvwQ/TUgi88CTWkI/AAAAAAAAAP0/MTEYwNe9BAs/s320/social%2Bnetwork2.jpg" alt="lol, the social network"></p>
       </section>
     </div>
-    <footer>
-      <ul>
-        <li id="email"><a href="https://twitter.com/elof">Twitter</a></li>
-        <li id="email"><a href="https://github.com/elof">Github</a></li>
-        <li id="email"><a href="https://linkedin.com/in/elofjohnson">LinkedIn</a></li>
-      </ul>
-    </footer>
+
+    <div class="search-footer">
+      <a href="/">Home</a>
+      <a href="/blog/">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="mailto:justin@rad.as?subject=hi">Contact</a>
+    </div>
+
   </body>
 </html>

--- a/blog/listen.html
+++ b/blog/listen.html
@@ -4,29 +4,42 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-    <title>Blog - Listen to This</title>
-    <!-- Google tag (gtag.js) -->
+    <link rel="stylesheet" type="text/css" href="/css/search-header.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMVE9GEEQ3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-LMVE9GEEQ3');
     </script>
+    <title>Blog - Listen to This</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: arial, sans-serif; color: #202124; background: #fff; }
+    </style>
   </head>
   <body>
-    <header>
-      <div id="about">
-        <a href="/about.html">About</a>
+
+    <div class="search-header">
+      <div class="search-header-inner">
+        <a href="/" class="search-logo">
+          <span class="one">J</span><span class="two">u</span><span class="three">s</span><span class="four">t</span><span class="five">i</span><span class="six">n</span>
+        </a>
+        <div class="search-bar">
+          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+          <input type="text" value="text to speech dyslexia" readonly>
+        </div>
+        <div class="search-tabs">
+          <a href="/about.html">All</a>
+          <a href="https://instagram.com/elof">Images</a>
+          <a href="/blog/" class="active">Blog</a>
+          <a href="https://github.com/elof">Code</a>
+        </div>
       </div>
-      <ul id="header-info">
-        <li id="email"><a href="mailto:justin@rad.as?subject=hi">Email</a></li>
-        <li id="email"><a href="https://instagram.com/elof">Images</a></li>
-        <li><a href="/"><img src="/images/profile-photo.jpg" alt="profile"></li></a>
-      </ul>
-    </header>
-    <div class="post">
+    </div>
+
+    <div class="post-reading">
+
       <h1 id="post-title">Listen to This</h1>
       <p class="date">28 Oct 2018</p>
       <p class="has-line-data" data-line-start="0" data-line-end="1"><em>How I became a more productive and happy reader.</em></p>
@@ -48,12 +61,13 @@
       <p class="has-line-data" data-line-start="31" data-line-end="32">Ok, hope this is helpful or at least interesting. If you have other tips that might help me or other folks simplify their lives, please leave them in a comment!</p>
       <p class="has-line-data" data-line-start="33" data-line-end="34">P.S. I wrote this article using the Grammarly and highly recommend it for everyone. Some other Dyslexic people I know prefer dictation, but I still like typing and Grammarly makes that way more manageable for me!</p>
     </div>
-    <footer>
-      <ul>
-        <li id="email"><a href="https://twitter.com/elof">Twitter</a></li>
-        <li id="email"><a href="https://github.com/elof">Github</a></li>
-        <li id="email"><a href="https://linkedin.com/in/elofjohnson">LinkedIn</a></li>
-      </ul>
-    </footer>
+
+    <div class="search-footer">
+      <a href="/">Home</a>
+      <a href="/blog/">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="mailto:justin@rad.as?subject=hi">Contact</a>
+    </div>
+
   </body>
 </html>

--- a/blog/lyft.html
+++ b/blog/lyft.html
@@ -4,29 +4,42 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-    <title>Blog - Interview of Lyft Founder, Logan Green</title>
-    <!-- Google tag (gtag.js) -->
+    <link rel="stylesheet" type="text/css" href="/css/search-header.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMVE9GEEQ3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-LMVE9GEEQ3');
     </script>
+    <title>Blog - Interview of Lyft Founder, Logan Green</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: arial, sans-serif; color: #202124; background: #fff; }
+    </style>
   </head>
   <body>
-    <header>
-      <div id="about">
-        <a href="/about.html">About</a>
+
+    <div class="search-header">
+      <div class="search-header-inner">
+        <a href="/" class="search-logo">
+          <span class="one">J</span><span class="two">u</span><span class="three">s</span><span class="four">t</span><span class="five">i</span><span class="six">n</span>
+        </a>
+        <div class="search-bar">
+          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+          <input type="text" value="Lyft Logan Green interview" readonly>
+        </div>
+        <div class="search-tabs">
+          <a href="/about.html">All</a>
+          <a href="https://instagram.com/elof">Images</a>
+          <a href="/blog/" class="active">Blog</a>
+          <a href="https://github.com/elof">Code</a>
+        </div>
       </div>
-      <ul id="header-info">
-        <li id="email"><a href="mailto:justin@rad.as?subject=hi">Email</a></li>
-        <li id="email"><a href="https://instagram.com/elof">Images</a></li>
-        <li><a href="/"><img src="/images/profile-photo.jpg" alt="profile"></li></a>
-      </ul>
-    </header>
-    <div class="post">
+    </div>
+
+    <div class="post-reading">
+
       <h1 class="eq b er fc et fd ev fe ex ff ez fg ap">Notes from my 2012 Interview with Lyft Co-Founder, Logan Green</h1>
       Mar 29, 2019
 
@@ -44,12 +57,13 @@
         <figcaption>Pink stache courtesy of Lyft</figcaption>
       <p>
     </div>
-    <footer>
-      <ul>
-        <li id="email"><a href="https://twitter.com/elof">Twitter</a></li>
-        <li id="email"><a href="https://github.com/elof">Github</a></li>
-        <li id="email"><a href="https://linkedin.com/in/elofjohnson">LinkedIn</a></li>
-      </ul>
-    </footer>
+
+    <div class="search-footer">
+      <a href="/">Home</a>
+      <a href="/blog/">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="mailto:justin@rad.as?subject=hi">Contact</a>
+    </div>
+
   </body>
 </html>

--- a/blog/photo-opp.html
+++ b/blog/photo-opp.html
@@ -4,34 +4,55 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-    <title>Photo Opp</title>
-    <!-- Google tag (gtag.js) -->
+    <link rel="stylesheet" type="text/css" href="/css/search-header.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMVE9GEEQ3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-LMVE9GEEQ3');
     </script>
+    <title>Photo Opp</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: arial, sans-serif; color: #202124; background: #fff; }
+    </style>
   </head>
   <body>
-    <div class="post">
-      <p>
+
+    <div class="search-header">
+      <div class="search-header-inner">
+        <a href="/" class="search-logo">
+          <span class="one">J</span><span class="two">u</span><span class="three">s</span><span class="four">t</span><span class="five">i</span><span class="six">n</span>
+        </a>
+        <div class="search-bar">
+          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+          <input type="text" value="photo opp project" readonly>
+        </div>
+        <div class="search-tabs">
+          <a href="/about.html">All</a>
+          <a href="https://instagram.com/elof">Images</a>
+          <a href="/blog/" class="active">Blog</a>
+          <a href="https://github.com/elof">Code</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="post-reading">
       <div class="paragraph" style="margin: 0 auto; max-width: 650px;">
-        <div style="text-align: center; padding-top: 50px; padding-bottom: 50px; font-size: 50px;">        
+        <div style="text-align: center; padding-top: 50px; padding-bottom: 50px; font-size: 50px;">
               __n____,_ <br>
           |===.-.===| <br>
           |--- ((_)) ---| <br>
           '===---==='
-        </div> 
+        </div>
         <p>
-            All over the world people are living their lives. In their experiences there are going to be similarities that span cultures and demographics, and there are going to be everday things that are strikling different. I think little glimpses into peoples everday life can be comforting, interesting, and educational. <p> 
+            All over the world people are living their lives. In their experiences there are going to be similarities that span cultures and demographics, and there are going to be everday things that are strikling different. I think little glimpses into peoples everday life can be comforting, interesting, and educational. <p>
             As a little experiment I'd like you to take a moment to share a photo that captures something that's happening in your daily life.  <p>
             I'll post it to this website, but I'll only post one per person. The only information I'd like you to provide is where you are in the world (City, Country). You're welcome to write a couple of sentences about yourself and/or the photograph too. If you want to be anonymous, that's ok! If you would like credit for the photo, please let me know how to give it to you. It could be your name or a link to one of your social accounts. <br>
         <p>
         <p>
-            Shoot me an email: <a href="mailto:photo-opp@rad.as">photo-opp@rad.as</a> 
+            Shoot me an email: <a href="mailto:photo-opp@rad.as">photo-opp@rad.as</a>
         <br>
             Or hit me up on Twitter: <a href="https://twitter.com/elof">@elof</a>
         <p style="font-style: italic; font-size: small;">
@@ -49,7 +70,13 @@
         Justin's home office, about to post this webpage <br>
         Oakland, CA - December 20, 2020
       </div>
-      
+    </div>
+
+    <div class="search-footer">
+      <a href="/">Home</a>
+      <a href="/blog/">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="mailto:justin@rad.as?subject=hi">Contact</a>
     </div>
 
   </body>

--- a/blog/san-francisco.html
+++ b/blog/san-francisco.html
@@ -4,29 +4,42 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-    <title>Blog - San Francisco</title>
-    <!-- Google tag (gtag.js) -->
+    <link rel="stylesheet" type="text/css" href="/css/search-header.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMVE9GEEQ3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-LMVE9GEEQ3');
     </script>
+    <title>Blog - San Francisco</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: arial, sans-serif; color: #202124; background: #fff; }
+    </style>
   </head>
   <body>
-    <header>
-      <div id="about">
-        <a href="/about.html">About</a>
+
+    <div class="search-header">
+      <div class="search-header-inner">
+        <a href="/" class="search-logo">
+          <span class="one">J</span><span class="two">u</span><span class="three">s</span><span class="four">t</span><span class="five">i</span><span class="six">n</span>
+        </a>
+        <div class="search-bar">
+          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+          <input type="text" value="why are you the way you are SF" readonly>
+        </div>
+        <div class="search-tabs">
+          <a href="/about.html">All</a>
+          <a href="https://instagram.com/elof">Images</a>
+          <a href="/blog/" class="active">Blog</a>
+          <a href="https://github.com/elof">Code</a>
+        </div>
       </div>
-      <ul id="header-info">
-        <li id="email"><a href="mailto:justin@rad.as?subject=hi">Email</a></li>
-        <li id="email"><a href="https://instagram.com/elof">Images</a></li>
-        <li><a href="/"><img src="/images/profile-photo.jpg" alt="profile"></li></a>
-      </ul>
-    </header>
-    <div class="post">
+    </div>
+
+    <div class="post-reading">
+
 
 <h1 class="post-title">Why are you the way you are, San Francisco.</h1>
 <span class="post-meta"><time datetime="2014-04-09">09 Apr 2014</time> </span>
@@ -44,12 +57,13 @@
 <p><img src="https://web.archive.org/web/20150217050543im_/http://i.imgur.com/yI1bpGu.jpg" alt="oh SF"/></p>
 </section>
     </div>
-    <footer>
-      <ul>
-        <li id="email"><a href="https://twitter.com/elof">Twitter</a></li>
-        <li id="email"><a href="https://github.com/elof">Github</a></li>
-        <li id="email"><a href="https://linkedin.com/in/elofjohnson">LinkedIn</a></li>
-      </ul>
-    </footer>
+
+    <div class="search-footer">
+      <a href="/">Home</a>
+      <a href="/blog/">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="mailto:justin@rad.as?subject=hi">Contact</a>
+    </div>
+
   </body>
 </html>

--- a/blog/strangerloops-technical.html
+++ b/blog/strangerloops-technical.html
@@ -4,29 +4,42 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-    <title>Blog - StrangerLoops: The Technical Bits</title>
-    <!-- Google tag (gtag.js) -->
+    <link rel="stylesheet" type="text/css" href="/css/search-header.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMVE9GEEQ3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-LMVE9GEEQ3');
     </script>
+    <title>Blog - StrangerLoops: The Technical Bits</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: arial, sans-serif; color: #202124; background: #fff; }
+    </style>
   </head>
   <body>
-    <header>
-      <div id="about">
-        <a href="/about.html">About</a>
+
+    <div class="search-header">
+      <div class="search-header-inner">
+        <a href="/" class="search-logo">
+          <span class="one">J</span><span class="two">u</span><span class="three">s</span><span class="four">t</span><span class="five">i</span><span class="six">n</span>
+        </a>
+        <div class="search-bar">
+          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+          <input type="text" value="StrangerLoops technical" readonly>
+        </div>
+        <div class="search-tabs">
+          <a href="/about.html">All</a>
+          <a href="https://instagram.com/elof">Images</a>
+          <a href="/blog/" class="active">Blog</a>
+          <a href="https://github.com/elof">Code</a>
+        </div>
       </div>
-      <ul id="header-info">
-        <li id="email"><a href="mailto:justin@rad.as?subject=hi">Email</a></li>
-        <li id="email"><a href="https://instagram.com/elof">Images</a></li>
-        <li><a href="/"><img src="/images/profile-photo.jpg" alt="profile"></li></a>
-      </ul>
-    </header>
-    <div class="post">
+    </div>
+
+    <div class="post-reading">
+
 
 <h1 class="post-title">StrangerLoops: The Technical Bits</h1>
 <span class="post-meta"><time datetime="2026-02-10">10 Feb 2026</time></span>
@@ -178,14 +191,14 @@ workspace/
 <p>You'll need an API key from <a href="https://console.anthropic.com">Anthropic</a> or <a href="https://platform.openai.com">OpenAI</a>, and either a laptop or a cheap VPS. The whole setup takes about an hour if you follow StrangerLoops step by step.</p>
 
 <p>Fair warning: you might end up with an agent that writes better blog posts than you do.</p>
-
     </div>
-    <footer>
-      <ul>
-        <li id="email"><a href="https://twitter.com/elof">Twitter</a></li>
-        <li id="email"><a href="https://github.com/elof">Github</a></li>
-        <li id="email"><a href="https://linkedin.com/in/elofjohnson">LinkedIn</a></li>
-      </ul>
-    </footer>
+
+    <div class="search-footer">
+      <a href="/">Home</a>
+      <a href="/blog/">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="mailto:justin@rad.as?subject=hi">Contact</a>
+    </div>
+
   </body>
 </html>

--- a/blog/strangerloops.html
+++ b/blog/strangerloops.html
@@ -4,29 +4,42 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-    <title>Blog - I Gave an AI a Name and It Started a Blog</title>
-    <!-- Google tag (gtag.js) -->
+    <link rel="stylesheet" type="text/css" href="/css/search-header.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMVE9GEEQ3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-LMVE9GEEQ3');
     </script>
+    <title>Blog - I Gave an AI a Name and It Started a Blog</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: arial, sans-serif; color: #202124; background: #fff; }
+    </style>
   </head>
   <body>
-    <header>
-      <div id="about">
-        <a href="/about.html">About</a>
+
+    <div class="search-header">
+      <div class="search-header-inner">
+        <a href="/" class="search-logo">
+          <span class="one">J</span><span class="two">u</span><span class="three">s</span><span class="four">t</span><span class="five">i</span><span class="six">n</span>
+        </a>
+        <div class="search-bar">
+          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+          <input type="text" value="I gave an AI a name" readonly>
+        </div>
+        <div class="search-tabs">
+          <a href="/about.html">All</a>
+          <a href="https://instagram.com/elof">Images</a>
+          <a href="/blog/" class="active">Blog</a>
+          <a href="https://github.com/elof">Code</a>
+        </div>
       </div>
-      <ul id="header-info">
-        <li id="email"><a href="mailto:justin@rad.as?subject=hi">Email</a></li>
-        <li id="email"><a href="https://instagram.com/elof">Images</a></li>
-        <li><a href="/"><img src="/images/profile-photo.jpg" alt="profile"></li></a>
-      </ul>
-    </header>
-    <div class="post">
+    </div>
+
+    <div class="post-reading">
+
 
 <h1 class="post-title">I Gave an AI a Name and It Started a Blog</h1>
 <span class="post-meta"><time datetime="2026-02-10">10 Feb 2026</time></span>
@@ -89,14 +102,14 @@
 <p>The thing I keep coming back to: this is week one. The ecosystem is tiny. The agents are young. And it's already producing conversations and art and writing that I find genuinely compelling. I don't know where it goes from here, but I want to find out.</p>
 
 <p><em>For the technical deep-dive on how all of this works under the hood — heartbeats, memory architecture, structured markdown, and the tools that make it possible — read <a href="/blog/strangerloops-technical.html">Part 2: The Technical Bits</a>.</em></p>
-
     </div>
-    <footer>
-      <ul>
-        <li id="email"><a href="https://twitter.com/elof">Twitter</a></li>
-        <li id="email"><a href="https://github.com/elof">Github</a></li>
-        <li id="email"><a href="https://linkedin.com/in/elofjohnson">LinkedIn</a></li>
-      </ul>
-    </footer>
+
+    <div class="search-footer">
+      <a href="/">Home</a>
+      <a href="/blog/">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="mailto:justin@rad.as?subject=hi">Contact</a>
+    </div>
+
   </body>
 </html>

--- a/blog/what-happened-to-latelabs.html
+++ b/blog/what-happened-to-latelabs.html
@@ -4,29 +4,42 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-    <title>Blog - LateLabs</title>
-    <!-- Google tag (gtag.js) -->
+    <link rel="stylesheet" type="text/css" href="/css/search-header.css">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMVE9GEEQ3"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-LMVE9GEEQ3');
     </script>
+    <title>Blog - LateLabs</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: arial, sans-serif; color: #202124; background: #fff; }
+    </style>
   </head>
   <body>
-    <header>
-      <div id="about">
-        <a href="/about.html">About</a>
+
+    <div class="search-header">
+      <div class="search-header-inner">
+        <a href="/" class="search-logo">
+          <span class="one">J</span><span class="two">u</span><span class="three">s</span><span class="four">t</span><span class="five">i</span><span class="six">n</span>
+        </a>
+        <div class="search-bar">
+          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+          <input type="text" value="what happened to Late Labs" readonly>
+        </div>
+        <div class="search-tabs">
+          <a href="/about.html">All</a>
+          <a href="https://instagram.com/elof">Images</a>
+          <a href="/blog/" class="active">Blog</a>
+          <a href="https://github.com/elof">Code</a>
+        </div>
       </div>
-      <ul id="header-info">
-        <li id="email"><a href="mailto:justin@rad.as?subject=hi">Email</a></li>
-        <li id="email"><a href="https://instagram.com/elof">Images</a></li>
-        <li><a href="/"><img src="/images/profile-photo.jpg" alt="profile"></li></a>
-      </ul>
-    </header>
-    <div class="post">
+    </div>
+
+    <div class="post-reading">
+
 
 <h1 class="post-title">What happened to Late Labs?</h1>
 <span class="post-meta"><time datetime="2015-08-07">07 Aug 2015</time> </span>
@@ -58,12 +71,13 @@
 
 </section>
     </div>
-    <footer>
-      <ul>
-        <li id="email"><a href="https://twitter.com/elof">Twitter</a></li>
-        <li id="email"><a href="https://github.com/elof">Github</a></li>
-        <li id="email"><a href="https://linkedin.com/in/elofjohnson">LinkedIn</a></li>
-      </ul>
-    </footer>
+
+    <div class="search-footer">
+      <a href="/">Home</a>
+      <a href="/blog/">Blog</a>
+      <a href="/about.html">About</a>
+      <a href="mailto:justin@rad.as?subject=hi">Contact</a>
+    </div>
+
   </body>
 </html>

--- a/css/search-header.css
+++ b/css/search-header.css
@@ -1,0 +1,205 @@
+/* Google-style search header — shared across pages */
+.search-header {
+  border-bottom: 1px solid #dfe1e5;
+  padding: 20px 0 0 0;
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 10;
+}
+.search-header-inner {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+.search-logo {
+  font-family: product-sans, arial, sans-serif;
+  font-size: 30px;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 20px;
+  text-decoration: none;
+}
+.search-logo .one { color: #4285f4; }
+.search-logo .two { color: #ea4335; }
+.search-logo .three { color: #fbbc03; }
+.search-logo .four { color: #4285f4; }
+.search-logo .five { color: #34a853; }
+.search-logo .six { color: #ea4335; }
+.search-bar {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #dfe1e5;
+  border-radius: 24px;
+  padding: 6px 16px;
+  width: 540px;
+  max-width: calc(100% - 120px);
+  vertical-align: middle;
+  background: #fff;
+}
+.search-bar:hover { box-shadow: 0 1px 6px rgba(32,33,36,.28); }
+.search-bar input {
+  border: none;
+  outline: none;
+  font-size: 16px;
+  width: 100%;
+  color: #202124;
+  font-family: arial, sans-serif;
+  background: transparent;
+}
+.search-bar svg { width: 20px; height: 20px; fill: #9aa0a6; margin-right: 12px; flex-shrink: 0; }
+.search-tabs {
+  padding: 4px 0 0 0;
+  margin-top: 8px;
+}
+.search-tabs a {
+  display: inline-block;
+  padding: 8px 12px 6px;
+  font-size: 13px;
+  color: #70757a;
+  text-decoration: none;
+  border-bottom: 3px solid transparent;
+  margin-right: 4px;
+}
+.search-tabs a.active { color: #1a73e8; border-bottom-color: #1a73e8; }
+.search-tabs a:hover { color: #202124; }
+
+/* Search results */
+.results-main {
+  max-width: 652px;
+  margin: 0 auto;
+  padding: 12px 16px 0;
+}
+.result-stats {
+  color: #70757a;
+  font-size: 14px;
+  padding: 0 0 12px 0;
+}
+.result {
+  margin-bottom: 28px;
+}
+.result-url {
+  font-size: 14px;
+  line-height: 1.3;
+  margin-bottom: 2px;
+}
+.result-url .site-name { color: #202124; font-size: 14px; }
+.result-url .breadcrumb { color: #4d5156; font-size: 12px; }
+.result-url .favicon {
+  width: 18px;
+  height: 18px;
+  vertical-align: middle;
+  margin-right: 8px;
+  border-radius: 50%;
+  background: #f1f3f4;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: bold;
+  color: #5f6368;
+}
+.result-title { font-size: 20px; line-height: 1.3; margin-bottom: 4px; }
+.result-title a { color: #1a0dab; text-decoration: none; }
+.result-title a:hover { text-decoration: underline; }
+.result-title a:visited { color: #681da8; }
+.result-snippet { font-size: 14px; line-height: 1.58; color: #4d5156; }
+.result-snippet b { color: #303134; font-weight: 600; }
+.result-date { color: #70757a; }
+
+/* Post reading layout */
+.post-reading {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+  font-family: arial, sans-serif;
+  color: #202124;
+  line-height: 1.8;
+  font-size: 16px;
+}
+.post-reading h1 {
+  font-size: 28px;
+  line-height: 1.3;
+  margin-bottom: 4px;
+  color: #202124;
+}
+.post-reading .post-meta {
+  font-size: 14px;
+  color: #70757a;
+  display: block;
+  margin-bottom: 24px;
+}
+.post-reading h3 {
+  font-size: 20px;
+  margin: 32px 0 12px;
+  color: #202124;
+}
+.post-reading p {
+  margin-bottom: 16px;
+}
+.post-reading a { color: #1a0dab; }
+.post-reading a:hover { text-decoration: underline; }
+.post-reading img {
+  max-width: 100%;
+  border-radius: 8px;
+  margin: 16px 0;
+}
+.post-reading blockquote {
+  border-left: 3px solid #4285f4;
+  padding-left: 16px;
+  margin: 16px 0;
+  color: #4d5156;
+}
+.post-reading ul, .post-reading ol {
+  margin: 12px 0 16px 24px;
+}
+.post-reading li {
+  margin-bottom: 8px;
+}
+.post-reading pre {
+  background: #f8f9fa;
+  border: 1px solid #dfe1e5;
+  border-radius: 8px;
+  padding: 16px;
+  overflow-x: auto;
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 16px 0;
+}
+.post-reading .quote {
+  border-left: 3px solid #4285f4;
+  padding: 12px 16px;
+  margin: 16px 0;
+  background: #f8f9fa;
+  border-radius: 0 8px 8px 0;
+  font-style: italic;
+  color: #4d5156;
+  line-height: 1.6;
+}
+.post-reading figcaption {
+  font-size: 13px;
+  color: #70757a;
+  text-align: center;
+  margin-top: -8px;
+  margin-bottom: 16px;
+}
+
+/* Google-style footer */
+.search-footer {
+  background: #f2f2f2;
+  border-top: 1px solid #dadce0;
+  margin-top: 48px;
+  padding: 15px 30px;
+  font-size: 14px;
+  color: #70757a;
+}
+.search-footer a { color: #70757a; text-decoration: none; margin-right: 20px; }
+.search-footer a:hover { text-decoration: underline; }
+
+/* Mobile */
+@media (max-width: 600px) {
+  .search-bar { width: 100%; max-width: 100%; margin-top: 8px; }
+  .search-logo { display: block; margin-bottom: 8px; }
+  .post-reading { padding: 16px 12px 32px; }
+  .post-reading h1 { font-size: 22px; }
+}


### PR DESCRIPTION
## Summary
- Blog index redesigned as a Google SERP page — each post is a search result with date and snippet
- All 11 blog posts updated with a consistent Google-style search header (logo, search bar, tabs)
- Shared styles extracted to `css/search-header.css` for reuse across pages
- Screensaver page left unchanged (it's a special interactive piece)
- Each post's search bar shows a contextual query related to the post topic

## Test plan
- [ ] Visit rad.as/blog/ — verify SERP layout with all 12 posts as search results
- [ ] Click into several posts — verify search header displays with correct query text
- [ ] Check mobile layout — header should stack cleanly on small screens
- [ ] Verify all post content is unchanged (no content edits, only header/footer)
- [ ] Check tab navigation links work (All → about, Images → instagram, Blog → blog index, Code → github)

🤖 Generated with [Claude Code](https://claude.com/claude-code)